### PR TITLE
Need to wait for the futures to finish before trying to build model

### DIFF
--- a/modules/model_fit_algo/lasseck2013/model_fit_algo.py
+++ b/modules/model_fit_algo/lasseck2013/model_fit_algo.py
@@ -18,6 +18,7 @@ from modules.utils import get_stratification_percent
 from scipy import stats
 from cv2 import matchTemplate, minMaxLoc
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import wait
 import progressbar
 from itertools import repeat
 from copy import copy
@@ -477,7 +478,8 @@ def model_fit_algo(config, rerun_statistics):
     chunks = np.array_split(labels_df.index, nprocs)
     if not get_model_fit_skip(config) or rerun_statistics:
         with ProcessPoolExecutor(nprocs) as executor:
-            executor.map(chunk_run_stats, chunks, repeat(labels_df), repeat(config))
+            fs = executor.map(chunk_run_stats, chunks, repeat(labels_df), repeat(config))
+        wait(fs)
 
     set_model_fit_skip(config)
 


### PR DESCRIPTION
I need to test this code for Python 3.6, but in 3.7 this will cause the code to fail because the statistics aren't available before it tries to build a model!