### PR TITLE
Moving to a more explicit futures syntax

### DIFF
--- a/modules/model_fit_algo/lasseck2013/model_fit_algo.py
+++ b/modules/model_fit_algo/lasseck2013/model_fit_algo.py
@@ -341,7 +341,7 @@ def build_X_y(labels_df, config):
 
     # Input Shape: (num_files, num_templates, 1, num_features)
     # Output Shape: (num_files, num_templates, num_features)
-    file_file_stats = np.array(file_file_stats).reshape(file_file_stats.shape[0], -1, 3)
+    file_file_stats = np.array(file_file_stats).reshape(labels_df.shape[0], -1, 3)
 
     # Short circuit return for only cross correlations
     if config["model_fit"].getboolean("cross_correlations_only"):
@@ -517,22 +517,22 @@ def model_fit_algo(config, rerun_statistics):
     # Get the processor counts
     nprocs = return_cpu_count(config)
 
+    # Define the parallel executor
+    executor = ProcessPoolExecutor(nprocs)
+
     # Run the statistics, if not already complete
     chunks = np.array_split(labels_df.index, nprocs)
     if not get_model_fit_skip(config) or rerun_statistics:
-        with ProcessPoolExecutor(nprocs) as executor:
-            fs = executor.map(
-                chunk_run_stats, chunks, repeat(labels_df), repeat(config)
-            )
-            wait(fs)
+        fs = [executor.submit(chunk_run_stats, chunk, labels_df, config) for chunk in chunks]
+        wait(fs)
 
     set_model_fit_skip(config)
 
     # Build the models
     chunks = np.array_split(labels_df.columns, nprocs)
-    with ProcessPoolExecutor(nprocs) as executor:
-        for ret in executor.map(
-            chunk_build_model, chunks, repeat(labels_df), repeat(config)
-        ):
-            if ret:
-                [print(x) for x in ret]
+    fs = [executor.submit(chunk_build_model, chunk, labels_df, config) for chunk in chunks]
+    wait(fs)
+
+    # Print the results, if any
+    for res in fs:
+        _ = [print(x) for x in res.result() if x]

--- a/modules/model_fit_algo/lasseck2013/model_fit_algo.py
+++ b/modules/model_fit_algo/lasseck2013/model_fit_algo.py
@@ -523,14 +523,19 @@ def model_fit_algo(config, rerun_statistics):
     # Run the statistics, if not already complete
     chunks = np.array_split(labels_df.index, nprocs)
     if not get_model_fit_skip(config) or rerun_statistics:
-        fs = [executor.submit(chunk_run_stats, chunk, labels_df, config) for chunk in chunks]
+        fs = [
+            executor.submit(chunk_run_stats, chunk, labels_df, config)
+            for chunk in chunks
+        ]
         wait(fs)
 
     set_model_fit_skip(config)
 
     # Build the models
     chunks = np.array_split(labels_df.columns, nprocs)
-    fs = [executor.submit(chunk_build_model, chunk, labels_df, config) for chunk in chunks]
+    fs = [
+        executor.submit(chunk_build_model, chunk, labels_df, config) for chunk in chunks
+    ]
     wait(fs)
 
     # Print the results, if any

--- a/modules/predict_algo/lasseck2013/predict_algo.py
+++ b/modules/predict_algo/lasseck2013/predict_algo.py
@@ -172,7 +172,7 @@ def chunk_run_prediction(chunk, train_labels_df, predict_labels_df, config):
 
     close_client()
 
-    return predict_proba
+    return chunk, predict_proba
 
 
 def run_prediction(column, train_labels_df, predict_labels_df, config):
@@ -231,32 +231,24 @@ def predict_algo(config):
         ]
 
     nprocs = return_cpu_count(config)
-
+    executor = ProcessPoolExecutor(nprocs)
+    
     # Run the statistics
     chunks = np.array_split(predict_labels_df.index, nprocs)
-    with ProcessPoolExecutor(nprocs) as executor:
-        fs = executor.map(
-            chunk_run_stats, chunks, repeat(train_labels_df), repeat(config)
-        )
-        wait(fs)
+    fs = [executor.submit(chunk_run_stats, chunk, train_labels_df, config) for chunk in chunks]
+    wait(fs)
 
     # Create a DF to store the results
     results_df = pd.DataFrame(index=predict_labels_df.index)
 
     # Run the predictions
     chunks = np.array_split(train_labels_df.columns, nprocs)
-    with ProcessPoolExecutor(nprocs) as executor:
-        for indices, probas in zip(
-            chunks,
-            executor.map(
-                chunk_run_prediction,
-                chunks,
-                repeat(train_labels_df),
-                repeat(predict_labels_df),
-                repeat(config),
-            ),
-        ):
-            for idx, proba in zip(indices, probas):
-                results_df[idx] = [pred[1] for pred in proba]
+    fs = [executor.submit(chunk_run_prediction, chunk, train_labels_df, predict_labels_df, config) for chunk in chunks]
+    wait(fs)
+
+    for res in fs:
+        indices, probas = res.result()
+        for idx, proba in zip(indices, probas):
+            results_df[idx] = [pred[1] for pred in proba]
 
     print(results_df.to_csv())

--- a/modules/predict_algo/lasseck2013/predict_algo.py
+++ b/modules/predict_algo/lasseck2013/predict_algo.py
@@ -232,10 +232,13 @@ def predict_algo(config):
 
     nprocs = return_cpu_count(config)
     executor = ProcessPoolExecutor(nprocs)
-    
+
     # Run the statistics
     chunks = np.array_split(predict_labels_df.index, nprocs)
-    fs = [executor.submit(chunk_run_stats, chunk, train_labels_df, config) for chunk in chunks]
+    fs = [
+        executor.submit(chunk_run_stats, chunk, train_labels_df, config)
+        for chunk in chunks
+    ]
     wait(fs)
 
     # Create a DF to store the results
@@ -243,7 +246,12 @@ def predict_algo(config):
 
     # Run the predictions
     chunks = np.array_split(train_labels_df.columns, nprocs)
-    fs = [executor.submit(chunk_run_prediction, chunk, train_labels_df, predict_labels_df, config) for chunk in chunks]
+    fs = [
+        executor.submit(
+            chunk_run_prediction, chunk, train_labels_df, predict_labels_df, config
+        )
+        for chunk in chunks
+    ]
     wait(fs)
 
     for res in fs:

--- a/modules/spect_gen_algo/lasseck2013/spect_gen_algo.py
+++ b/modules/spect_gen_algo/lasseck2013/spect_gen_algo.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import wait
 from multiprocessing import cpu_count
 import progressbar
 from itertools import repeat
@@ -310,5 +311,6 @@ def spect_gen_algo(config):
     # Create a ProcessPoolExecutor, run:
     # -> Wrap everything in a ProgressBar
     # -> Async process everything
-    with ProcessPoolExecutor(nprocs) as executor:
-        executor.map(chunk_preprocess, chunks, repeat(config))
+    executor = ProcessPoolExecutor(nprocs)
+    fs = [executor.submit(chunk_preprocess, chunk, config) for chunk in chunks]
+    wait(fs)

--- a/scripts/find_high_cross_correlations.py
+++ b/scripts/find_high_cross_correlations.py
@@ -30,7 +30,7 @@ def generate_ff_stats(stats_df, species_found_df):
     # Use the mono_idx to insert the correct value in the correct place!
     all_file_file_statistics = [None] * stats_df.shape[0]
     for item in items:
-        mono_idx = stats_df.index.get_loc(item['label'])
+        mono_idx = stats_df.index.get_loc(item["label"])
         _, file_file_stats = cursor_item_to_stats(item)
         all_file_file_statistics[mono_idx] = [
             file_file_stats[found] for found in species_found_df.index.values
@@ -42,6 +42,7 @@ def generate_ff_stats(stats_df, species_found_df):
     # Output Dims: n_files, n_templates
     npify = np.array(all_file_file_statistics)
     return npify[:, :, :, 0].reshape(stats_df.shape[0], -1)
+
 
 def high_cc(chunk, species_found, config):
     if len(chunk) != 0:
@@ -99,13 +100,15 @@ executor = ProcessPoolExecutor(nprocs)
 chunk_species_not_found = np.array_split(species_not_found, nprocs)
 chunk_species_found = np.array_split(species_found, nprocs)
 
-futs = [executor.submit(high_cc, chunk, species_found, config) for chunk in chunk_species_not_found]
+futs = [
+    executor.submit(high_cc, chunk, species_found, config)
+    for chunk in chunk_species_not_found
+]
 wait(futs)
 
-with open("gt9.txt", "w") as gt, \
-     open("7-9.txt", "w") as sn, \
-     open("4-6.txt", "w") as fs, \
-     open("1-3.txt", "w") as ot:
+with open("gt9.txt", "w") as gt, open("7-9.txt", "w") as sn, open(
+    "4-6.txt", "w"
+) as fs, open("1-3.txt", "w") as ot:
     for res in futs:
         indices, rows = res.result()
         for idx, row in zip(indices.index.values, rows):

--- a/scripts/find_high_cross_correlations.py
+++ b/scripts/find_high_cross_correlations.py
@@ -106,9 +106,10 @@ futs = [
 ]
 wait(futs)
 
-with open("gt9.txt", "w") as gt, open("7-9.txt", "w") as sn, open(
-    "4-6.txt", "w"
-) as fs, open("1-3.txt", "w") as ot:
+with open("gt9.txt", "w") as gt, \
+     open("7-9.txt", "w") as sn, \
+     open("4-6.txt", "w") as fs, \
+     open("1-3.txt", "w") as ot:
     for res in futs:
         indices, rows = res.result()
         for idx, row in zip(indices.index.values, rows):

--- a/scripts/find_important_templates.py
+++ b/scripts/find_important_templates.py
@@ -193,7 +193,10 @@ close_client()
 # -> Don't use
 nprocs = return_cpu_count(config)
 executor = ProcessPoolExecutor(nprocs)
-fs = [executor.submit(gen_results_df, species_found, species_not_found, identifiers_list) for x in range(100)]
+fs = [
+    executor.submit(gen_results_df, species_found, species_not_found, identifiers_list)
+    for x in range(100)
+]
 wait(fs)
 
 # Concatenate all results

--- a/scripts/find_important_templates.py
+++ b/scripts/find_important_templates.py
@@ -123,7 +123,7 @@ def identify_templates(X, y, identifiers):
     return good_templates
 
 
-def gen_results_df(_, species_found, species_not_found, identifiers_list):
+def gen_results_df(species_found, species_not_found, identifiers_list):
     init_client(config)
     X, y = sampled_X_y(species_found, species_not_found)
     close_client()
@@ -192,18 +192,12 @@ close_client()
 # Now, run a loop to identify useful templates
 # -> Don't use
 nprocs = return_cpu_count(config)
-with ProcessPoolExecutor(nprocs) as executor:
-    results = executor.map(
-        gen_results_df,
-        range(100),
-        repeat(species_found),
-        repeat(species_not_found),
-        repeat(identifiers_list),
-    )
-    wait(results)
+executor = ProcessPoolExecutor(nprocs)
+fs = [executor.submit(gen_results_df, species_found, species_not_found, identifiers_list) for x in range(100)]
+wait(fs)
 
 # Concatenate all results
-results_df = pd.concat(results)
+results_df = pd.concat([res.result() for res in fs])
 
 # Keep any weights above 0.35
 results_df = results_df[results_df["weight"] >= 0.35]


### PR DESCRIPTION
The style like:

```python
with ProcessPoolExector(nprocs) as executor:
    fs = executor.map(...)
    wait(fs)
```
doesn't work :-1:. Moving to the more verbose syntax.
