### PR TITLE
Explicitly cast to float32 before running matchTemplates from opencv

### DIFF
--- a/modules/model_fit_algo/lasseck2013/model_fit_algo.py
+++ b/modules/model_fit_algo/lasseck2013/model_fit_algo.py
@@ -32,7 +32,9 @@ from cv2 import matchTemplate
 from cv2 import minMaxLoc
 
 
-def generate_raw_blurred_spectrogram(spectrogram, normalization_factor, gaussian_blur_sigma):
+def generate_raw_blurred_spectrogram(
+    spectrogram, normalization_factor, gaussian_blur_sigma
+):
     """Given a normalized spectrogram
 
     Recreate the raw spectrogram and apply a gaussian filter
@@ -44,7 +46,9 @@ def generate_raw_blurred_spectrogram(spectrogram, normalization_factor, gaussian
     """
 
     raw_spectrogram = spectrogram * normalization_factor
-    return apply_gaussian_filter(raw_spectrogram, gaussian_blur_sigma)
+    return apply_gaussian_filter(raw_spectrogram, gaussian_blur_sigma).astype(
+        "float32", casting="safe"
+    )
 
 
 def binary_classify(correct, predicted):


### PR DESCRIPTION
I didn't look too far into changes to numpy and pandas, but somewhere I am generating `float64` instead of `float32`. Explicitly cast to `float32` in `generate_raw_blurred_spectrogram` to ensure `float32`'s are sent to `matchTemplate` in OpenCV