### PR TITLE
Add matchTemplate algorithm as option

### DIFF
--- a/config/opensoundscape.ini
+++ b/config/opensoundscape.ini
@@ -40,6 +40,8 @@ min_samples_split = 3
 cross_correlations_only = False
 labels_list =
 stratification_percent = 33.3
+# Options: TM_CCOEFF, TM_CCOEFF_NORMED, TM_CCORR, TM_CCORR_NORMED, TM_SQDIFF, TM_SQDIFF_NORMED
+template_match_algorithm = TM_CCORR_NORMED
 
 [predict]
 algo = lasseck2013

--- a/modules/config_check.py
+++ b/modules/config_check.py
@@ -1,0 +1,83 @@
+from difflib import get_close_matches
+
+
+def ini_section_and_keys_exists(
+    default_config, override_config, override_config_filename
+):
+    """ Given the parsed INI files
+
+    Do the sections and keys in the override config exist in the default config?
+
+    Input:
+        default_config: The unmodified config/opensoundscape.ini INI object
+        override_config: The user modifications made to the opensoundscape configuration
+        override_config_filename: The filename for the override file
+    """
+
+    for section in override_config.keys():
+        # -> First, does the section even exist?
+        if not section in default_config.keys():
+            close_matches = get_close_matches(section, default_config.keys())
+            print(
+                f"ERROR: From {override_config_filename}, section '{section}' isn't recognized!"
+            )
+            if close_matches:
+                print(f"-> did you mean: {' '.join(close_matches)}")
+            exit()
+
+        # Second, do the keys even exist?
+        for key in override_config[section].keys():
+            if not key in default_config[section].keys():
+                close_matches = get_close_matches(key, default_config[section].keys())
+                print(
+                    f"ERROR: From {override_config_filename}, section {section}, key '{key}' isn't recognized!"
+                )
+                if close_matches:
+                    print(f"-> did you mean: {' '.join(close_matches)}")
+                exit()
+
+
+def matchTemplate_algorithm_exists(config):
+    """ Given the parsed INI files
+    
+    Check that the matchTemplate algorithm exists, potential options:
+    TM_CCOEFF, TM_CCOEFF_NORMED, TM_CCORR, TM_CCORR_NORMED, TM_SQDIFF,
+    TM_SQDIFF_NORMED
+
+    Input:
+        config: The opensoundscape configuration
+    """
+
+    options = [
+        "TM_CCOEFF",
+        "TM_CCOEFF_NORMED",
+        "TM_CCORR",
+        "TM_CCORR_NORMED",
+        "TM_SQDIFF",
+        "TM_SQDIFF_NORMED",
+    ]
+    algo = config["model_fit"].get("template_match_algorithm")
+    if algo not in options:
+        raise ValueError(
+            f"The template matching algorithm chosen was {algo}, valid options: {' '.join(options)}"
+        )
+
+
+def config_checks(config):
+    """ Given the parsed INI files
+
+    The entry point for configuration checks
+
+    Input:
+        default_config: The unmodified config/opensoundscape.ini INI object
+        override_config: The user modifications made to the opensoundscape configuration
+        override_config_filename: The filename for the override file
+    
+    Output:
+        None
+
+    Raises:
+        Nothing, but can various functions will exit
+    """
+
+    matchTemplate_algorithm_exists(config)

--- a/modules/model_fit_algo/lasseck2013/model_fit_algo.py
+++ b/modules/model_fit_algo/lasseck2013/model_fit_algo.py
@@ -28,6 +28,7 @@ from modules.view import extract_segments
 from modules.utils import return_cpu_count
 from modules.image_utils import apply_gaussian_filter
 from modules.utils import get_stratification_percent
+from modules.utils import get_template_matching_algorithm
 from cv2 import matchTemplate
 from cv2 import minMaxLoc
 
@@ -260,7 +261,9 @@ def get_file_file_stats(df_one, spec_one, normal_one, labels_df, config):
                 and row["x_max"] - row["x_min"] <= spec_one.shape[1]
             ):
                 output_stats = matchTemplate(
-                    spec_one[y_min_target:y_max_target, :], row["segments"], 5
+                    spec_one[y_min_target:y_max_target, :],
+                    row["segments"],
+                    get_template_matching_algorithm(config),
                 )
                 _, max_val, _, max_loc = minMaxLoc(output_stats)
                 match_stats_dict[idx_two][idx][0] = max_val


### PR DESCRIPTION
Allow the user to configure the matchTemplate algorithm. Add configuration checks to ensure the user picks one that exists.